### PR TITLE
Remove extra tile_data$size <- 2

### DIFF
--- a/R/geom-statebins.r
+++ b/R/geom-statebins.r
@@ -150,7 +150,6 @@ GeomStatebins <- ggplot2::ggproto("GeomStatebins", ggplot2::Geom,
                         radius = grid::unit(6, "pt")) {
 
     tile_data <- data
-    tile_data$size <- 2
     tile_data$colour <- border_col
     tile_data$size <- border_size
 


### PR DESCRIPTION
  I see that   `tile_data$size <- 2` on lines 152:155 is set twice without being used. I removed the first one as it would be over written by the latter. 

If this is necessary, can you explain why? I don't want to miss anything.